### PR TITLE
Adds "commit-colors" to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Git Hooks are scripts that run automatically every time a particular event occur
 - [git-hooks-php](https://github.com/BernardoSilva/git-hooks-php) - Git hooks for PHP based projects.
 - [commandbox-githooks](https://github.com/elpete/commandbox-githooks) - Git hooks for CommandBox CFML based projects.
 - [hooks4git](https://pypi.org/project/hooks4git/) - A simple, flexible and language agnostic git hook management approach.
+- [Commit Colors](https://github.com/sparkbox/commit-colors) - See a color swatch in your terminal every time you author a commit.
 
 ## Articles
 


### PR DESCRIPTION
Project link: https://github.com/sparkbox/commit-colors

Commit colors is a project that displays a color swatch in your terminal each time you author a commit. The color displayed is the hexadecimal color that corresponds to your truncated commit ID.

I'd like to include it because it's a fun way to use commit hooks, similar to other listed projects like [Lolcommits](https://github.com/mroth/lolcommits), and [Podmena](https://github.com/bmwant/podmena).