### PR TITLE
Improve shell scripts

### DIFF
--- a/post-receive/post-receive-specific-folder
+++ b/post-receive/post-receive-specific-folder
@@ -3,15 +3,15 @@
 target_branch="production"
 working_tree="PATH_TO_DEPLOY"
 
-while read oldrev newrev refname
+while read -r oldrev newrev refname
 do
-    branch=$(git rev-parse --symbolic --abbrev-ref $refname)
-    if [ -n "$branch" ] && [ "$target_branch" == "$branch" ]; then
-    
+    branch=$(git rev-parse --symbolic --abbrev-ref "$refname")
+    if [ -n "$branch" ] && [ "$target_branch" = "$branch" ]; then
+
        GIT_WORK_TREE=$working_tree git checkout $target_branch -f
        NOW=$(date +"%Y%m%d-%H%M")
-       git tag release_$NOW $target_branch
-    
+       git tag "release_$NOW" $target_branch
+
        echo "   /==============================="
        echo "   | DEPLOYMENT COMPLETED"
        echo "   | Target branch: $target_branch"

--- a/post-rewrite/post-rewrite-move-refs
+++ b/post-rewrite/post-rewrite-move-refs
@@ -29,7 +29,7 @@ handle_rewrite() {
     done
   fi
 }
-while read line; do handle_rewrite $line; done
+while read -r line; do handle_rewrite "$line"; done
 
 # TODO:
 #   Print recommended rebase commands for each branch found by

--- a/pre-commit/pre-commit-swiftlint
+++ b/pre-commit/pre-commit-swiftlint
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# Git Hook for SwiftLint 
+# Git Hook for SwiftLint
 # Runs at every commit and checks for an error.
 # For the test, you can run `git commit` with an empty` commit message`
 
 export PATH=/usr/local/bin:$PATH
 
-LINT=$(which swiftlint)
+LINT=$(command -v swiftlint)
 
 if [[ -e "${LINT}" ]]; then
 	echo "SwiftLint Start..."
-	echo $(pwd)
+	echo "$PWD"
 else
 	echo "SwiftLint does not exist, download from https://github.com/realm/SwiftLint"
 	exit 1
@@ -18,22 +18,22 @@ fi
 
 RESULT=$($LINT lint --quiet --config .swiftlint.yml)
 
-if [ "$RESULT" == '' ]; then
+if [ -z "$RESULT" ]; then
 	printf "SwiftLint Finished.\n"
 else
 	echo ""
 	printf "SwiftLint Failed. Please check below:\n"
 
 	while read -r line; do
-		FILEPATH=$(echo $line | cut -d : -f 1)
-		L=$(echo $line | cut -d : -f 2)
-		C=$(echo $line | cut -d : -f 3)
-		TYPE=$(echo $line | cut -d : -f 4 | cut -c 2-)
-		MESSAGE=$(echo $line | cut -d : -f 5 | cut -c 2-)
-		DESCRIPTION=$(echo $line | cut -d : -f 6 | cut -c 2-)
-		printf "\n $TYPE\n"
-		printf "    $FILEPATH:$L:$C\n"
-		printf "    $MESSAGE - $DESCRIPTION\n"
+		FILEPATH=$(echo "$line" | cut -d : -f 1)
+		L=$(echo "$line" | cut -d : -f 2)
+		C=$(echo "$line" | cut -d : -f 3)
+		TYPE=$(echo "$line" | cut -d : -f 4 | cut -c 2-)
+		MESSAGE=$(echo "$line" | cut -d : -f 5 | cut -c 2-)
+		DESCRIPTION=$(echo "$line" | cut -d : -f 6 | cut -c 2-)
+		printf '\n %s\n' "$TYPE"
+		echo "    $FILEPATH:$L:$C"
+		echo "    $MESSAGE - $DESCRIPTION"
 	done <<< "$RESULT"
 
 	printf "\nCOMMIT ABORTED. Please fix them before commiting.\n"

--- a/pre-push/pre-push-protect-branches
+++ b/pre-push/pre-push-protect-branches
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Prevents force-pushing to master
 
-BRANCH=`git rev-parse --abbrev-ref HEAD`
-PUSH_COMMAND=`ps -ocommand= -p $PPID`
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PUSH_COMMAND=$(ps -ocommand= -p $PPID)
 PROTECTED_BRANCHES="^(master|dev|release-*|patch-*)"
 FORCE_PUSH="force|delete|-f"
 

--- a/pre-rebase/pre-rebase-rebaselock
+++ b/pre-rebase/pre-rebase-rebaselock
@@ -5,9 +5,9 @@
 # $2 -- the branch being rebased (or empty when rebasing the current branch).
 #
 branch="$2"
-[ -n "$branch" ] || branch=`git rev-parse --abbrev-ref HEAD`
+[ -n "$branch" ] || branch=$(git rev-parse --abbrev-ref HEAD)
 lock="branch.${branch}.rebaselock"
-if [ x`git config --bool "$lock"` = xtrue ]; then
+if [ "$(git config --bool "$lock")" = true ]; then
 echo "pre-rebase hook: \"$lock\" is set to true. Refusing to rebase."
 exit 1
 fi

--- a/pre-receive/pre-receive-ban-on-push-to-branch
+++ b/pre-receive/pre-receive-ban-on-push-to-branch
@@ -6,7 +6,7 @@ changedBranch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 blockedUsers=(junior1 junior2)
 
 if [[ ${blockedUsers[*]} =~ $USER ]]; then
-    if [ $changedBranch == "master" ]; then
+    if [ "$changedBranch" == "master" ]; then
         echo "You are not allowed commit changes in this branch"
         exit 1
     fi

--- a/prepare-commit-msg/prepare-commit-msg-jira
+++ b/prepare-commit-msg/prepare-commit-msg-jira
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Git Hook for JIRA_TASK_ID
 # Adds to the top of your commit message `JIRA_TASK_ID`, based on the prefix of the current branch `feature/AWG-562-add-linter`
@@ -9,18 +9,18 @@ if [ -z "$BRANCHES_TO_SKIP" ]; then
 fi
 
 COMMIT_FILE=$1
-COMMIT_MSG=$(cat $1)
+COMMIT_MSG=$(cat "$1")
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 JIRA_ID_REGEX="[A-Z0-9]{1,10}-?[A-Z0-9]+"
 JIRA_ID_IN_CURRENT_BRANCH_NAME=$(echo "$CURRENT_BRANCH" | grep -Eo "$JIRA_ID_REGEX")
 JIRA_ID_IN_COMMIT_MESSAGE=$(echo "$COMMIT_MSG" | grep -Eo "$JIRA_ID_REGEX")
 
-if [ ! -z "$JIRA_ID_IN_COMMIT_MESSAGE" ]; then
+if [ -n "$JIRA_ID_IN_COMMIT_MESSAGE" ]; then
   if [ "$JIRA_ID_IN_COMMIT_MESSAGE" != "$JIRA_ID_IN_CURRENT_BRANCH_NAME" ]; then
     echo "Error, your commit message JIRA_TASK_ID='$JIRA_ID_IN_COMMIT_MESSAGE' is not equal to current branch JIRA_TASK_ID='$JIRA_ID_IN_CURRENT_BRANCH_NAME'"
     exit 1
   fi
-elif [ ! -z "$JIRA_ID_IN_CURRENT_BRANCH_NAME" ]; then
-  echo "$JIRA_ID_IN_CURRENT_BRANCH_NAME $COMMIT_MSG" > $COMMIT_FILE
+elif [ -n "$JIRA_ID_IN_CURRENT_BRANCH_NAME" ]; then
+  echo "$JIRA_ID_IN_CURRENT_BRANCH_NAME $COMMIT_MSG" > "$COMMIT_FILE"
   echo "JIRA ID '$JIRA_ID_IN_CURRENT_BRANCH_NAME', matched in current branch name, prepended to commit message. (Use --no-verify to skip)"
 fi


### PR DESCRIPTION
This fixes some slight inaccuracies within the shell scripts including

- Use `-r` so backslashes aren't mangled
-  Use `$PWD` for "speed"
- Use `$()` instead of deprecated backticks for subshells
- Quote arguments to prevent word splitting
- Don't use `==` in single equals sign
- Use `command -v` instead of which (which is deprecated in the [last version of debian](https://lwn.net/Articles/874049))

Some of these aren't strictly required in these exact cases, but in my opinion its better to be safe than sorry, and people are going to be using these as baseline examples, so it might be a good idea to make 'em robust