### PR TITLE
Improve compatability of Bash shebang

### DIFF
--- a/post-receive/post-receive-specific-folder
+++ b/post-receive/post-receive-specific-folder
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 target_branch="production"
 working_tree="PATH_TO_DEPLOY"

--- a/post-rewrite/post-rewrite-move-refs
+++ b/post-rewrite/post-rewrite-move-refs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Git "post-rewrite" hook to make local refs move automatically on rewrites.
 set -e -u
 command="$1"

--- a/pre-commit/pre-commit-swiftlint
+++ b/pre-commit/pre-commit-swiftlint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Git Hook for SwiftLint
 # Runs at every commit and checks for an error.

--- a/pre-push/pre-push-protect-branches
+++ b/pre-push/pre-push-protect-branches
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Prevents force-pushing to master
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/pre-receive/pre-receive-ban-on-push-to-branch
+++ b/pre-receive/pre-receive-ban-on-push-to-branch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Git Hook for ban on push to master branch
 
 changedBranch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')

--- a/prepare-commit-msg/prepare-commit-msg-jira
+++ b/prepare-commit-msg/prepare-commit-msg-jira
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Git Hook for JIRA_TASK_ID
 # Adds to the top of your commit message `JIRA_TASK_ID`, based on the prefix of the current branch `feature/AWG-562-add-linter`


### PR DESCRIPTION
The `#!/bin/bash` shebang does not work in all cases:
- By default on NixOS, `bash` is not in `/bin`
- By default on OpenBSD (and other BSDs), `bash` is not in `bin`
- If Bash is installed to any location not in `/bin` (any custom installation location like `/usr/local/bin`)

This fixes those issues by making the shebang work in all possible scenarios.